### PR TITLE
Add a maxDepth option to avoid infinite recursion

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ self.maxLines = 2500;
 self.tailNumLines = 100; 
 // filename of log downloaded with downloadLog()
 self.logFilename = 'log.txt';
+// max recursion depth for logged objects
+self.maxDepth = 3
 ```
 
 ### Outputting examples <a name="outputting"></a>

--- a/debugout.js
+++ b/debugout.js
@@ -18,6 +18,7 @@ function debugout() {
 	self.maxLines = 2500; // if autoTrim is true, this many most recent lines are saved
 	self.tailNumLines = 100; // how many lines tail() will retrieve
 	self.logFilename = 'debugout.txt'; // filename of log downloaded with downloadLog()
+	self.maxDepth = null; // max recursion depth for logged objects
 
 	// vars
 	self.depth = 0;
@@ -175,6 +176,10 @@ function debugout() {
 	}
 	// format type accordingly, recursively if necessary
 	this.formatType = function(type, obj) {
+		if (self.maxDepth && self.depth >= self.maxDepth) {
+			return '... (max-depth reached)';
+		}
+
 		switch(type) {
 			case 'Object' :
 				self.currentResult += '{\n';


### PR DESCRIPTION
Hello,

The following code currently crashes no matter how debugout is set up due to an inifinite recursion within the formatType method :

```
var test = { a: null };
test.a = test;
bugout.log(test);
```

This push request adds a `maxDepth` option that, if set to a non-falsy value, stop the recursive calls if the depth counter reached the associated value.