### PR TITLE
Fix problems downloading larger files

### DIFF
--- a/debugout.js
+++ b/debugout.js
@@ -82,17 +82,16 @@ function debugout() {
 	}
 	// immediately downloads the log - for desktop browser use
 	this.downloadLog = function() {
-	    var file = "data:text/plain;charset=utf-8,";
 	    var logFile = self.getLog();
-	    var encoded = encodeURIComponent(logFile);
-	    file += encoded;
-	    var a = document.createElement('a');
-	    a.href = file;
-	    a.target   = '_blank';
-	    a.download = self.logFilename;
-	    document.body.appendChild(a);
-	    a.click();
-	    a.remove();
+            var blob = new Blob([logFile], { type: 'data:text/plain;charset=utf-8' });
+            var a = document.createElement('a');
+            a.href = window.URL.createObjectURL(blob);
+            a.target = '_blank';
+            a.download = filename;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            window.URL.revokeObjectURL(a.href);
 	}
 	// clears the log
 	this.clear = function() {


### PR DESCRIPTION
The previous mechanism for downloading the file did not cope well on Chrome when downloading logs with higher (but not particularly large) numbers of lines, e.g. 25,000 lines. Trying to download a file in Chrome with 25,000 lines would result in "Failed - Network Error" in Chrome.

This change alters the download function to create a Blob and create an object URL from the blob. I have not tested this in IE, but the API calls should working on IE10 or above.